### PR TITLE
Close encoder

### DIFF
--- a/message.go
+++ b/message.go
@@ -975,6 +975,7 @@ func (p *Multipart) AddText(mediaType string, r io.Reader) error {
 
 	reader := bufio.NewReader(r)
 	encoder := qp.NewWriter(w)
+	defer encoder.Close()
 	buffer := make([]byte, maxLineLen)
 	for {
 		read, err := reader.Read(buffer[:])


### PR DESCRIPTION
Need to call Close() on encoder to flush writer
