### PR TITLE
Always write newlines after closing encoder

### DIFF
--- a/message.go
+++ b/message.go
@@ -975,7 +975,12 @@ func (p *Multipart) AddText(mediaType string, r io.Reader) error {
 
 	reader := bufio.NewReader(r)
 	encoder := qp.NewWriter(w)
-	defer encoder.Close()
+	defer func() {
+		encoder.Close()
+		fmt.Fprintf(w, crlf)
+		fmt.Fprintf(w, crlf)
+	}()
+
 	buffer := make([]byte, maxLineLen)
 	for {
 		read, err := reader.Read(buffer[:])
@@ -987,8 +992,6 @@ func (p *Multipart) AddText(mediaType string, r io.Reader) error {
 		}
 		encoder.Write(buffer[:read])
 	}
-	fmt.Fprintf(w, crlf)
-	fmt.Fprintf(w, crlf)
 	return nil
 }
 


### PR DESCRIPTION
Without doing this, it will create newlines in the wrong place which especially seems to be a concern when it comes to multibyte UTF8 characters as it cuts them midway and causes them to be incorrect.