### PR TITLE
Fixes issue with malformed missing multipart ending

### DIFF
--- a/message.go
+++ b/message.go
@@ -336,7 +336,32 @@ func (m *Message) Bytes() []byte {
 	//
 	// Body
 	//
-	output.ReadFrom(m.Body)
+	boundary := m.boundary()
+	// If we have a boundary, we need to read line by line to ensure
+	// the body has an opening and closing boundary
+	if boundary != "" {
+		scanner := bufio.NewScanner(m.Body)
+		open, closed := false, false
+		for scanner.Scan() {
+			line := scanner.Text()
+			output.WriteString(line)
+			output.WriteString(crlf)
+			if open && line == "--"+boundary+"--" {
+				closed = true
+			}
+
+			if line == "--"+boundary {
+				open = true
+			}
+		}
+
+		if open && !closed {
+			output.WriteString("--" + boundary + "--")
+			output.WriteString(crlf)
+		}
+	} else {
+		output.ReadFrom(m.Body)
+	}
 
 	return output.Bytes()
 }

--- a/message_test.go
+++ b/message_test.go
@@ -654,3 +654,172 @@ This package was designed with the idea of eventually replacing the one in the s
 
 	ioutil.WriteFile("tests/gopher.eml", msg.Bytes(), os.ModePerm)
 }
+
+// TestMissingMultipartBoundaryClosure
+func TestMissingMultipartBoundaryClosure(t *testing.T) {
+	raw := `Content-Type: multipart/mixed; boundary="boundary"
+Subject: hello
+Date: Wed, 01 Apr 2026 13:26:15 -0500
+Mime-Version: 1.0
+Message-ID: <971515439a5d14113793366f@nowhere.localhost>
+
+--boundary
+Content-Type: text/plain
+
+This is the body of the message.
+`
+
+	msg, err := ReadMessage(bytes.NewBuffer([]byte(raw)))
+	if err != nil {
+		t.Fatal("Failed parsing message:", err)
+	}
+
+	bytes := msg.Bytes()
+	// String should end with --boundary--
+	if !strings.HasSuffix(string(bytes), "--boundary--\r\n") {
+		t.Error("Expected message to end with closing boundary, but it did not.")
+	}
+}
+
+// TestHasMultipartClosure
+func TestHasMultipartClosure(t *testing.T) {
+	raw := `Content-Type: multipart/mixed; boundary="boundary"
+Subject: hello
+Date: Wed, 01 Apr 2026 13:26:15 -0500
+Mime-Version: 1.0
+Message-ID: <971515439a5d14113793366f@nowhere.localhost>
+
+--boundary
+Content-Type: text/plain
+
+This is the body of the message.
+--boundary--
+`
+
+	msg, err := ReadMessage(bytes.NewBuffer([]byte(raw)))
+	if err != nil {
+		t.Fatal("Failed parsing message:", err)
+	}
+
+	bytes := msg.Bytes()
+	// String should end with --boundary--
+	if !strings.HasSuffix(string(bytes), "--boundary--\r\n") {
+		t.Error("Expected message to end with closing boundary, but it did not.")
+	}
+}
+
+// TestHasMultipartClosureOtherFormat
+func TestHasMultipartClosureOtherFormat(t *testing.T) {
+	raw := `Content-Type: multipart/mixed; boundary="917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c"
+Subject: hello
+Date: Wed, 01 Apr 2026 13:26:15 -0500
+Mime-Version: 1.0
+Message-ID: <971515439a5d14113793366f@nowhere.localhost>
+
+--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c
+Content-Type: text/plain
+
+This is the body of the message.
+--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c--
+`
+
+	msg, err := ReadMessage(bytes.NewBuffer([]byte(raw)))
+	if err != nil {
+		t.Fatal("Failed parsing message:", err)
+	}
+
+	bytes := msg.Bytes()
+	// String should end with --boundary--
+	if !strings.HasSuffix(string(bytes), "--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c--\r\n") {
+		t.Error("Expected message to end with closing boundary, but it did not.")
+	}
+}
+
+// TestMissingMultipartClosureOtherFormat
+func TestMissingMultipartClosureOtherFormat(t *testing.T) {
+	raw := `Content-Type: multipart/mixed; boundary="917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c"
+Subject: hello
+Date: Wed, 01 Apr 2026 13:26:15 -0500
+Mime-Version: 1.0
+Message-ID: <971515439a5d14113793366f@nowhere.localhost>
+
+--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c
+Content-Type: text/plain
+
+This is the body of the message.
+`
+
+	msg, err := ReadMessage(bytes.NewBuffer([]byte(raw)))
+	if err != nil {
+		t.Fatal("Failed parsing message:", err)
+	}
+
+	bytes := msg.Bytes()
+	// String should end with --boundary--
+	if !strings.HasSuffix(string(bytes), "--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c--\r\n") {
+		t.Error("Expected message to end with closing boundary, but it did not.")
+	}
+}
+
+// TestMissingMultipartClosureOtherFormatMultipart
+func TestMissingMultipartClosureOtherFormatMultipart(t *testing.T) {
+	raw := `Content-Type: multipart/mixed; boundary="917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c"
+Subject: hello
+Date: Wed, 01 Apr 2026 13:26:15 -0500
+Mime-Version: 1.0
+Message-ID: <971515439a5d14113793366f@nowhere.localhost>
+
+--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c
+Content-Type: text/plain
+
+This is the body of the message.
+
+--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c
+Content-Type: text/html
+
+This is the body of the message.
+`
+
+	msg, err := ReadMessage(bytes.NewBuffer([]byte(raw)))
+	if err != nil {
+		t.Fatal("Failed parsing message:", err)
+	}
+
+	bytes := msg.Bytes()
+	// String should end with --boundary--
+	if !strings.HasSuffix(string(bytes), "--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c--\r\n") {
+		t.Error("Expected message to end with closing boundary, but it did not.")
+	}
+}
+
+// TestHasMultipartClosureOtherFormatMultipart
+func TestHasMultipartClosureOtherFormatMultipart(t *testing.T) {
+	raw := `Content-Type: multipart/mixed; boundary="917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c"
+Subject: hello
+Date: Wed, 01 Apr 2026 13:26:15 -0500
+Mime-Version: 1.0
+Message-ID: <971515439a5d14113793366f@nowhere.localhost>
+
+--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c
+Content-Type: text/plain
+
+This is the body of the message.
+
+--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c
+Content-Type: text/html
+
+This is the body of the message.
+--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c--
+`
+
+	msg, err := ReadMessage(bytes.NewBuffer([]byte(raw)))
+	if err != nil {
+		t.Fatal("Failed parsing message:", err)
+	}
+
+	bytes := msg.Bytes()
+	// String should end with --boundary--
+	if !strings.HasSuffix(string(bytes), "--917321ed4871eb52ad7103e61491b8cd14b64cf61be75b5820f17ed65b2c--\r\n") {
+		t.Error("Expected message to end with closing boundary, but it did not.")
+	}
+}


### PR DESCRIPTION
If we don't have a valid closing boundary here, we should detect that and fix the raw email format so that we don't cause a read error in other processes when reading from the raw mime.